### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/prernagarsole0704/c7d53b1e-644e-4719-b0a2-5ba920b71ed5/445469dd-08f3-45b6-9101-f48b8eaddf9c/_apis/work/boardbadge/1482527e-dd76-45df-b704-6fd87707c5ac)](https://dev.azure.com/prernagarsole0704/c7d53b1e-644e-4719-b0a2-5ba920b71ed5/_boards/board/t/445469dd-08f3-45b6-9101-f48b8eaddf9c/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/prernagarsole0704/c7d53b1e-644e-4719-b0a2-5ba920b71ed5/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.